### PR TITLE
Feature ekf state support

### DIFF
--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 ext {
     PUBLISH_ARTIFACT_ID = 'dronekit-android'
-    PUBLISH_VERSION = '2.3.26'
+    PUBLISH_VERSION = '2.3.27'
     PROJECT_DESCRIPTION = "Android DroneKit client library."
     PROJECT_LABELS = ['3DR', '3DR Services', 'DroneAPI', 'Android', 'DroneKit']
     PROJECT_LICENSES = ['Apache-2.0']
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 21
-        versionCode 20326
+        versionCode 20327
         versionName PUBLISH_VERSION
     }
 

--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 ext {
     PUBLISH_ARTIFACT_ID = 'dronekit-android'
-    PUBLISH_VERSION = '2.3.27'
+    PUBLISH_VERSION = '2.3.28'
     PROJECT_DESCRIPTION = "Android DroneKit client library."
     PROJECT_LABELS = ['3DR', '3DR Services', 'DroneAPI', 'Android', 'DroneKit']
     PROJECT_LICENSES = ['Apache-2.0']
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 21
-        versionCode 20327
+        versionCode 20328
         versionName PUBLISH_VERSION
     }
 

--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -47,8 +47,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:21.0.3'
-    compile 'com.google.android.gms:play-services-base:6.5.87'
+    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.google.android.gms:play-services-base:7.3.0'
 
     compile project(':dependencyLibs:Mavlink')
     compile files('libs/Mavlink.jar')

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java
@@ -139,6 +139,11 @@ public class AttributeEvent {
     public static final String STATE_DISCONNECTED = PACKAGE_NAME + ".STATE_DISCONNECTED";
 
     /**
+     * Signals updates of the ekf status.
+     */
+    public static final String STATE_EKF_REPORT = PACKAGE_NAME + ".STATE_EKF_REPORT";
+
+    /**
      * Signals update of the vehicle mode.
      */
     public static final String STATE_VEHICLE_MODE = PACKAGE_NAME + ".STATE_VEHICLE_MODE";

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java
@@ -144,6 +144,11 @@ public class AttributeEvent {
     public static final String STATE_EKF_REPORT = PACKAGE_NAME + ".STATE_EKF_REPORT";
 
     /**
+     * Signals updates to the ekf position state.
+     */
+    public static final String STATE_EKF_POSITION = PACKAGE_NAME + ".STATE_EKF_POSITION";
+
+    /**
      * Signals update of the vehicle mode.
      */
     public static final String STATE_VEHICLE_MODE = PACKAGE_NAME + ".STATE_VEHICLE_MODE";
@@ -175,5 +180,4 @@ public class AttributeEvent {
      * @see {@link com.o3dr.services.android.lib.drone.camera.GoPro}
      */
     public static final String GOPRO_STATE_UPDATED = PACKAGE_NAME + ".GOPRO_STATE_UPDATED";
-
 }

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.aidl
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.aidl
@@ -1,0 +1,3 @@
+package com.o3dr.services.android.lib.drone.property;
+
+parcelable EkfStatus;

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
@@ -15,17 +15,23 @@ public class EkfStatus implements Parcelable {
     private static final String TAG = EkfStatus.class.getSimpleName();
     private static final int FLAGS_BIT_COUNT = 16;
 
-    private final static int[] EKF_FLAGS = {
-            EKF_STATUS_FLAGS.EKF_ATTITUDE,
-            EKF_STATUS_FLAGS.EKF_VELOCITY_HORIZ,
-            EKF_STATUS_FLAGS.EKF_VELOCITY_VERT,
-            EKF_STATUS_FLAGS.EKF_POS_HORIZ_REL,
-            EKF_STATUS_FLAGS.EKF_POS_HORIZ_ABS,
-            EKF_STATUS_FLAGS.EKF_POS_VERT_ABS,
-            EKF_STATUS_FLAGS.EKF_POS_VERT_AGL,
-            EKF_STATUS_FLAGS.EKF_CONST_POS_MODE,
-            EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_REL,
-            EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_ABS
+    private enum EkfFlags  {
+            EKF_ATTITUDE(EKF_STATUS_FLAGS.EKF_ATTITUDE),
+            EKF_VELOCITY_HORIZ(EKF_STATUS_FLAGS.EKF_VELOCITY_HORIZ),
+            EKF_VELOCITY_VERT(EKF_STATUS_FLAGS.EKF_VELOCITY_VERT),
+            EKF_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_POS_HORIZ_REL),
+            EKF_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_POS_HORIZ_ABS),
+            EKF_POS_VERT_ABS(EKF_STATUS_FLAGS.EKF_POS_VERT_ABS),
+            EKF_POS_VERT_AGL(EKF_STATUS_FLAGS.EKF_POS_VERT_AGL),
+            EKF_CONST_POS_MODE(EKF_STATUS_FLAGS.EKF_CONST_POS_MODE),
+            EKF_PRED_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_REL),
+            EKF_PRED_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_ABS);
+
+        final int value;
+
+        EkfFlags(int value){
+            this.value = value;
+        }
     };
 
     private float velocityVariance;
@@ -53,8 +59,9 @@ public class EkfStatus implements Parcelable {
     }
 
     private void fromShortToBitSet(short flags){
-        for(int i = 0; i < EKF_FLAGS.length; i++){
-            this.flags.set(i, (flags & EKF_FLAGS[i]) != 0);
+        final EkfFlags[] ekfFlags = EkfFlags.values();
+        for(int i = 0; i < ekfFlags.length; i++){
+            this.flags.set(i, (flags & ekfFlags[i].value) != 0);
         }
     }
 
@@ -105,10 +112,12 @@ public class EkfStatus implements Parcelable {
      */
     public boolean isPositionOk(boolean armed){
         if(armed){
-            return this.flags.get(4) && !this.flags.get(7);
+            return this.flags.get(EkfFlags.EKF_POS_HORIZ_ABS.ordinal())
+                    && !this.flags.get(EkfFlags.EKF_CONST_POS_MODE.ordinal());
         }
         else{
-            return this.flags.get(4) || this.flags.get(9);
+            return this.flags.get(EkfFlags.EKF_POS_HORIZ_ABS.ordinal())
+                    || this.flags.get(EkfFlags.EKF_PRED_POS_HORIZ_ABS.ordinal());
         }
     }
 

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
@@ -1,0 +1,148 @@
+package com.o3dr.services.android.lib.drone.property;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.MAVLink.enums.EKF_STATUS_FLAGS;
+
+import java.util.BitSet;
+
+/**
+ * Created by Fredia Huya-Kouadio on 5/22/15.
+ */
+public class EkfStatus implements Parcelable {
+
+    private static final String TAG = EkfStatus.class.getSimpleName();
+    private static final int FLAGS_BIT_COUNT = 16;
+
+    private final static int[] EKF_FLAGS = {
+            EKF_STATUS_FLAGS.EKF_ATTITUDE,
+            EKF_STATUS_FLAGS.EKF_VELOCITY_HORIZ,
+            EKF_STATUS_FLAGS.EKF_VELOCITY_VERT,
+            EKF_STATUS_FLAGS.EKF_POS_HORIZ_REL,
+            EKF_STATUS_FLAGS.EKF_POS_HORIZ_ABS,
+            EKF_STATUS_FLAGS.EKF_POS_VERT_ABS,
+            EKF_STATUS_FLAGS.EKF_POS_VERT_AGL,
+            EKF_STATUS_FLAGS.EKF_CONST_POS_MODE,
+            EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_REL,
+            EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_ABS
+    };
+
+    private float velocityVariance;
+    private float horizontalPositionVariance;
+    private float verticalPositionVariance;
+    private float compassVariance;
+    private float terrainAltitudeVariance;
+
+    private final BitSet flags;
+
+    public EkfStatus(){
+        this.flags = new BitSet(FLAGS_BIT_COUNT);
+    }
+
+    public EkfStatus(short flags, float compassVariance, float horizontalPositionVariance, float
+            terrainAltitudeVariance, float velocityVariance, float verticalPositionVariance) {
+        this();
+        this.compassVariance = compassVariance;
+        this.horizontalPositionVariance = horizontalPositionVariance;
+        this.terrainAltitudeVariance = terrainAltitudeVariance;
+        this.velocityVariance = velocityVariance;
+        this.verticalPositionVariance = verticalPositionVariance;
+
+        fromShortToBitSet(flags);
+    }
+
+    private void fromShortToBitSet(short flags){
+        for(int i = 0; i < EKF_FLAGS.length; i++){
+            this.flags.set(i, (flags & EKF_FLAGS[i]) != 0);
+        }
+    }
+
+    public float getTerrainAltitudeVariance() {
+        return terrainAltitudeVariance;
+    }
+
+    public void setTerrainAltitudeVariance(float terrainAltitudeVariance) {
+        this.terrainAltitudeVariance = terrainAltitudeVariance;
+    }
+
+    public float getVelocityVariance() {
+        return velocityVariance;
+    }
+
+    public void setVelocityVariance(float velocityVariance) {
+        this.velocityVariance = velocityVariance;
+    }
+
+    public float getVerticalPositionVariance() {
+        return verticalPositionVariance;
+    }
+
+    public void setVerticalPositionVariance(float verticalPositionVariance) {
+        this.verticalPositionVariance = verticalPositionVariance;
+    }
+
+    public float getHorizontalPositionVariance() {
+        return horizontalPositionVariance;
+    }
+
+    public void setHorizontalPositionVariance(float horizontalPositionVariance) {
+        this.horizontalPositionVariance = horizontalPositionVariance;
+    }
+
+    public float getCompassVariance() {
+        return compassVariance;
+    }
+
+    public void setCompassVariance(float compassVariance) {
+        this.compassVariance = compassVariance;
+    }
+
+    /**
+     * Returns true if the horizontal absolute position is ok, and home position is set.
+     * @param armed
+     * @return
+     */
+    public boolean isPositionOk(boolean armed){
+        if(armed){
+            return this.flags.get(4) && !this.flags.get(7);
+        }
+        else{
+            return this.flags.get(4) || this.flags.get(9);
+        }
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeFloat(this.velocityVariance);
+        dest.writeFloat(this.horizontalPositionVariance);
+        dest.writeFloat(this.verticalPositionVariance);
+        dest.writeFloat(this.compassVariance);
+        dest.writeFloat(this.terrainAltitudeVariance);
+        dest.writeSerializable(this.flags);
+    }
+
+    private EkfStatus(Parcel in) {
+        this.velocityVariance = in.readFloat();
+        this.horizontalPositionVariance = in.readFloat();
+        this.verticalPositionVariance = in.readFloat();
+        this.compassVariance = in.readFloat();
+        this.terrainAltitudeVariance = in.readFloat();
+        this.flags = (BitSet) in.readSerializable();
+    }
+
+    public static final Parcelable.Creator<EkfStatus> CREATOR = new Parcelable.Creator<EkfStatus>() {
+        public EkfStatus createFromParcel(Parcel source) {
+            return new EkfStatus(source);
+        }
+
+        public EkfStatus[] newArray(int size) {
+            return new EkfStatus[size];
+        }
+    };
+}

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java
@@ -15,24 +15,26 @@ public class EkfStatus implements Parcelable {
     private static final String TAG = EkfStatus.class.getSimpleName();
     private static final int FLAGS_BIT_COUNT = 16;
 
-    private enum EkfFlags  {
-            EKF_ATTITUDE(EKF_STATUS_FLAGS.EKF_ATTITUDE),
-            EKF_VELOCITY_HORIZ(EKF_STATUS_FLAGS.EKF_VELOCITY_HORIZ),
-            EKF_VELOCITY_VERT(EKF_STATUS_FLAGS.EKF_VELOCITY_VERT),
-            EKF_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_POS_HORIZ_REL),
-            EKF_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_POS_HORIZ_ABS),
-            EKF_POS_VERT_ABS(EKF_STATUS_FLAGS.EKF_POS_VERT_ABS),
-            EKF_POS_VERT_AGL(EKF_STATUS_FLAGS.EKF_POS_VERT_AGL),
-            EKF_CONST_POS_MODE(EKF_STATUS_FLAGS.EKF_CONST_POS_MODE),
-            EKF_PRED_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_REL),
-            EKF_PRED_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_ABS);
+    private enum EkfFlags {
+        EKF_ATTITUDE(EKF_STATUS_FLAGS.EKF_ATTITUDE),
+        EKF_VELOCITY_HORIZ(EKF_STATUS_FLAGS.EKF_VELOCITY_HORIZ),
+        EKF_VELOCITY_VERT(EKF_STATUS_FLAGS.EKF_VELOCITY_VERT),
+        EKF_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_POS_HORIZ_REL),
+        EKF_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_POS_HORIZ_ABS),
+        EKF_POS_VERT_ABS(EKF_STATUS_FLAGS.EKF_POS_VERT_ABS),
+        EKF_POS_VERT_AGL(EKF_STATUS_FLAGS.EKF_POS_VERT_AGL),
+        EKF_CONST_POS_MODE(EKF_STATUS_FLAGS.EKF_CONST_POS_MODE),
+        EKF_PRED_POS_HORIZ_REL(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_REL),
+        EKF_PRED_POS_HORIZ_ABS(EKF_STATUS_FLAGS.EKF_PRED_POS_HORIZ_ABS);
 
         final int value;
 
-        EkfFlags(int value){
+        EkfFlags(int value) {
             this.value = value;
         }
-    };
+    }
+
+    ;
 
     private float velocityVariance;
     private float horizontalPositionVariance;
@@ -42,7 +44,7 @@ public class EkfStatus implements Parcelable {
 
     private final BitSet flags;
 
-    public EkfStatus(){
+    public EkfStatus() {
         this.flags = new BitSet(FLAGS_BIT_COUNT);
     }
 
@@ -58,9 +60,11 @@ public class EkfStatus implements Parcelable {
         fromShortToBitSet(flags);
     }
 
-    private void fromShortToBitSet(short flags){
+    private void fromShortToBitSet(short flags) {
         final EkfFlags[] ekfFlags = EkfFlags.values();
-        for(int i = 0; i < ekfFlags.length; i++){
+        final int ekfFlagsCount = ekfFlags.length;
+
+        for (int i = 0; i < ekfFlagsCount; i++) {
             this.flags.set(i, (flags & ekfFlags[i].value) != 0);
         }
     }
@@ -107,15 +111,15 @@ public class EkfStatus implements Parcelable {
 
     /**
      * Returns true if the horizontal absolute position is ok, and home position is set.
+     *
      * @param armed
      * @return
      */
-    public boolean isPositionOk(boolean armed){
-        if(armed){
+    public boolean isPositionOk(boolean armed) {
+        if (armed) {
             return this.flags.get(EkfFlags.EKF_POS_HORIZ_ABS.ordinal())
                     && !this.flags.get(EkfFlags.EKF_CONST_POS_MODE.ordinal());
-        }
-        else{
+        } else {
             return this.flags.get(EkfFlags.EKF_POS_HORIZ_ABS.ordinal())
                     || this.flags.get(EkfFlags.EKF_PRED_POS_HORIZ_ABS.ordinal());
         }
@@ -133,6 +137,7 @@ public class EkfStatus implements Parcelable {
         dest.writeFloat(this.verticalPositionVariance);
         dest.writeFloat(this.compassVariance);
         dest.writeFloat(this.terrainAltitudeVariance);
+
         dest.writeSerializable(this.flags);
     }
 
@@ -142,6 +147,7 @@ public class EkfStatus implements Parcelable {
         this.verticalPositionVariance = in.readFloat();
         this.compassVariance = in.readFloat();
         this.terrainAltitudeVariance = in.readFloat();
+
         this.flags = (BitSet) in.readSerializable();
     }
 
@@ -154,4 +160,5 @@ public class EkfStatus implements Parcelable {
             return new EkfStatus[size];
         }
     };
+
 }

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java
@@ -19,11 +19,12 @@ public class State implements Parcelable {
     private String autopilotErrorId;
     private int mavlinkVersion = INVALID_MAVLINK_VERSION;
     private long flightStartTime;
+    private EkfStatus ekfStatus;
 
     public State(){}
 
     public State(boolean isConnected, VehicleMode mode, boolean armed, boolean flying, String autopilotErrorId,
-                 int mavlinkVersion, String calibrationStatus, long flightStartTime){
+                 int mavlinkVersion, String calibrationStatus, long flightStartTime, EkfStatus ekfStatus){
         this.isConnected = isConnected;
         this.vehicleMode = mode;
         this.armed = armed;
@@ -32,6 +33,7 @@ public class State implements Parcelable {
         this.autopilotErrorId = autopilotErrorId;
         this.mavlinkVersion = mavlinkVersion;
         this.calibrationStatus = calibrationStatus;
+        this.ekfStatus = ekfStatus;
     }
 
     public boolean isConnected() {
@@ -110,6 +112,14 @@ public class State implements Parcelable {
         this.flightStartTime = flightStartTime;
     }
 
+    public EkfStatus getEkfStatus() {
+        return ekfStatus;
+    }
+
+    public void setEkfStatus(EkfStatus ekfStatus) {
+        this.ekfStatus = ekfStatus;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -117,7 +127,7 @@ public class State implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeByte(isConnected ? (byte) 1: (byte) 0);
+        dest.writeByte(isConnected ? (byte) 1 : (byte) 0);
         dest.writeByte(armed ? (byte) 1 : (byte) 0);
         dest.writeByte(isFlying ? (byte) 1 : (byte) 0);
         dest.writeString(this.calibrationStatus);
@@ -125,6 +135,7 @@ public class State implements Parcelable {
         dest.writeString(this.autopilotErrorId);
         dest.writeInt(this.mavlinkVersion);
         dest.writeLong(this.flightStartTime);
+        dest.writeParcelable(this.ekfStatus, 0);
     }
 
     private State(Parcel in) {
@@ -136,6 +147,7 @@ public class State implements Parcelable {
         this.autopilotErrorId = in.readString();
         this.mavlinkVersion = in.readInt();
         this.flightStartTime = in.readLong();
+        this.ekfStatus = in.readParcelable(EkfStatus.class.getClassLoader());
     }
 
     public static final Creator<State> CREATOR = new Creator<State>() {

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java
@@ -15,25 +15,31 @@ public class State implements Parcelable {
     private boolean armed;
     private boolean isFlying;
     private String calibrationStatus;
-    private VehicleMode vehicleMode = VehicleMode.UNKNOWN;
     private String autopilotErrorId;
     private int mavlinkVersion = INVALID_MAVLINK_VERSION;
     private long flightStartTime;
-    private EkfStatus ekfStatus;
 
-    public State(){}
+    private VehicleMode vehicleMode = VehicleMode.UNKNOWN;
+    private EkfStatus ekfStatus = new EkfStatus();
+
+    public State() {
+    }
 
     public State(boolean isConnected, VehicleMode mode, boolean armed, boolean flying, String autopilotErrorId,
-                 int mavlinkVersion, String calibrationStatus, long flightStartTime, EkfStatus ekfStatus){
+                 int mavlinkVersion, String calibrationStatus, long flightStartTime, EkfStatus ekfStatus) {
         this.isConnected = isConnected;
-        this.vehicleMode = mode;
         this.armed = armed;
         this.isFlying = flying;
         this.flightStartTime = flightStartTime;
         this.autopilotErrorId = autopilotErrorId;
         this.mavlinkVersion = mavlinkVersion;
         this.calibrationStatus = calibrationStatus;
-        this.ekfStatus = ekfStatus;
+
+        if (ekfStatus != null)
+            this.ekfStatus = ekfStatus;
+
+        if (mode != null)
+            this.vehicleMode = mode;
     }
 
     public boolean isConnected() {
@@ -84,19 +90,19 @@ public class State implements Parcelable {
         this.autopilotErrorId = autopilotErrorId;
     }
 
-    public boolean isWarning(){
+    public boolean isWarning() {
         return TextUtils.isEmpty(autopilotErrorId);
     }
 
-    public boolean isCalibrating(){
+    public boolean isCalibrating() {
         return calibrationStatus != null;
     }
 
-    public void setCalibration(String message){
+    public void setCalibration(String message) {
         this.calibrationStatus = message;
     }
 
-    public String getCalibrationStatus(){
+    public String getCalibrationStatus() {
         return this.calibrationStatus;
     }
 
@@ -114,10 +120,6 @@ public class State implements Parcelable {
 
     public EkfStatus getEkfStatus() {
         return ekfStatus;
-    }
-
-    public void setEkfStatus(EkfStatus ekfStatus) {
-        this.ekfStatus = ekfStatus;
     }
 
     @Override

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/util/version/VersionUtils.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/util/version/VersionUtils.java
@@ -8,7 +8,7 @@ import android.content.pm.PackageManager;
  */
 public class VersionUtils {
 
-    public static final int LIB_VERSION = 20212;
+    public static final int LIB_VERSION = 20213;
 
     public static int getVersion(Context context){
         try {

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/util/version/VersionUtils.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/util/version/VersionUtils.java
@@ -8,7 +8,7 @@ import android.content.pm.PackageManager;
  */
 public class VersionUtils {
 
-    public static final int LIB_VERSION = 20211;
+    public static final int LIB_VERSION = 20212;
 
     public static int getVersion(Context context){
         try {

--- a/ServiceApp/build.gradle
+++ b/ServiceApp/build.gradle
@@ -4,10 +4,11 @@ apply plugin: 'org.robolectric'
 
 dependencies {
 
-    compile 'com.google.android.gms:play-services-location:6.5.87'
+    compile 'com.google.android.gms:play-services-analytics:7.3.0'
+    compile 'com.google.android.gms:play-services-location:7.3.0'
 
-    compile 'com.android.support:support-v4:21.0.3'
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.android.support:cardview-v7:21.0.0'
     compile 'com.android.support:recyclerview-v7:21.0.2'
 

--- a/ServiceApp/src/org/droidplanner/services/android/api/DroneApi.java
+++ b/ServiceApp/src/org/droidplanner/services/android/api/DroneApi.java
@@ -764,6 +764,10 @@ public final class DroneApi extends IDroneApi.Stub implements DroneEventsListene
             case GOPRO_STATUS_UPDATE:
                 droneEvent = AttributeEvent.GOPRO_STATE_UPDATED;
                 break;
+
+            case EKF_STATUS_UPDATE:
+                droneEvent = AttributeEvent.STATE_EKF_REPORT;
+                break;
         }
 
         if (droneEvent != null) {

--- a/ServiceApp/src/org/droidplanner/services/android/api/DroneApi.java
+++ b/ServiceApp/src/org/droidplanner/services/android/api/DroneApi.java
@@ -768,6 +768,10 @@ public final class DroneApi extends IDroneApi.Stub implements DroneEventsListene
             case EKF_STATUS_UPDATE:
                 droneEvent = AttributeEvent.STATE_EKF_REPORT;
                 break;
+
+            case EKF_POSITION_STATE_UPDATE:
+                droneEvent = AttributeEvent.STATE_EKF_POSITION;
+                break;
         }
 
         if (droneEvent != null) {

--- a/ServiceApp/src/org/droidplanner/services/android/api/DroneApiUtils.java
+++ b/ServiceApp/src/org/droidplanner/services/android/api/DroneApiUtils.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.MAVLink.Messages.ApmModes;
 import com.MAVLink.Messages.MAVLinkMessage;
+import com.MAVLink.ardupilotmega.msg_ekf_status_report;
 import com.MAVLink.ardupilotmega.msg_mag_cal_progress;
 import com.MAVLink.ardupilotmega.msg_mag_cal_report;
 import com.MAVLink.enums.MAG_CAL_STATUS;
@@ -28,6 +29,7 @@ import com.o3dr.services.android.lib.drone.property.Altitude;
 import com.o3dr.services.android.lib.drone.property.Attitude;
 import com.o3dr.services.android.lib.drone.property.Battery;
 import com.o3dr.services.android.lib.drone.property.CameraProxy;
+import com.o3dr.services.android.lib.drone.property.EkfStatus;
 import com.o3dr.services.android.lib.drone.property.FootPrint;
 import com.o3dr.services.android.lib.drone.property.Gps;
 import com.o3dr.services.android.lib.drone.property.GuidedState;
@@ -358,10 +360,13 @@ public class DroneApiUtils {
         ApmModes droneMode = droneState.getMode();
         AccelCalibration accelCalibration = drone.getCalibrationSetup();
         String calibrationMessage = accelCalibration.isCalibrating() ? accelCalibration.getMessage() : null;
+        final msg_ekf_status_report ekfStatus = droneState.getEkfStatus();
 
         return new State(isConnected, DroneApiUtils.getVehicleMode(droneMode), droneState.isArmed(), droneState.isFlying(),
                 droneState.getErrorId(), drone.getMavlinkVersion(), calibrationMessage,
-                droneState.getFlightStartTime());
+                droneState.getFlightStartTime(),
+                new EkfStatus(ekfStatus.flags, ekfStatus.compass_variance, ekfStatus.pos_horiz_variance, ekfStatus
+                        .terrain_alt_variance, ekfStatus.velocity_variance, ekfStatus.pos_vert_variance));
     }
 
     static Parameters getParameters(Drone drone, Context context) {

--- a/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
@@ -16,6 +16,7 @@ import com.MAVLink.common.msg_global_position_int;
 import com.MAVLink.common.msg_gps_raw_int;
 import com.MAVLink.common.msg_heartbeat;
 import com.MAVLink.common.msg_mission_current;
+import com.MAVLink.common.msg_mission_item;
 import com.MAVLink.common.msg_nav_controller_output;
 import com.MAVLink.common.msg_radio_status;
 import com.MAVLink.common.msg_raw_imu;
@@ -28,6 +29,7 @@ import com.MAVLink.enums.MAV_MODE_FLAG;
 import com.MAVLink.enums.MAV_STATE;
 import com.MAVLink.enums.MAV_SYS_STATUS_SENSOR;
 
+import org.droidplanner.core.drone.variables.Home;
 import org.droidplanner.core.model.Drone;
 
 /**
@@ -167,6 +169,13 @@ public class MavLinkMsgHandler {
             //*************** EKF State handling ******************//
             case msg_ekf_status_report.MAVLINK_MSG_ID_EKF_STATUS_REPORT:
                 drone.getState().setEkfStatus((msg_ekf_status_report) msg);
+                break;
+
+            case msg_mission_item.MAVLINK_MSG_ID_MISSION_ITEM:
+                msg_mission_item missionItem = (msg_mission_item) msg;
+                if(missionItem.seq == Home.HOME_WAYPOINT_INDEX){
+                    drone.getHome().setHome(missionItem);
+                }
                 break;
 
             default:

--- a/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
@@ -3,6 +3,7 @@ package org.droidplanner.core.MAVLink;
 import com.MAVLink.Messages.ApmModes;
 import com.MAVLink.Messages.MAVLinkMessage;
 import com.MAVLink.ardupilotmega.msg_camera_feedback;
+import com.MAVLink.ardupilotmega.msg_ekf_status_report;
 import com.MAVLink.ardupilotmega.msg_gopro_get_response;
 import com.MAVLink.ardupilotmega.msg_gopro_heartbeat;
 import com.MAVLink.ardupilotmega.msg_gopro_set_response;
@@ -27,7 +28,6 @@ import com.MAVLink.enums.MAV_MODE_FLAG;
 import com.MAVLink.enums.MAV_STATE;
 import com.MAVLink.enums.MAV_SYS_STATUS_SENSOR;
 
-import org.droidplanner.core.helpers.coordinates.Coord2D;
 import org.droidplanner.core.model.Drone;
 
 /**
@@ -162,6 +162,11 @@ public class MavLinkMsgHandler {
             case msg_mag_cal_progress.MAVLINK_MSG_ID_MAG_CAL_PROGRESS:
             case msg_mag_cal_report.MAVLINK_MSG_ID_MAG_CAL_REPORT:
                 drone.getMagnetometerCalibration().processCalibrationMessage(msg);
+                break;
+
+            //*************** EKF State handling ******************//
+            case msg_ekf_status_report.MAVLINK_MSG_ID_EKF_STATUS_REPORT:
+                drone.getState().setEkfStatus((msg_ekf_status_report) msg);
                 break;
 
             default:

--- a/dependencyLibs/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
@@ -246,6 +246,11 @@ public class DroneInterfaces {
 		 * The ekf status was updated.
 		 */
 		EKF_STATUS_UPDATE,
+
+		/**
+		 * The horizontal position is ok, and the home position is available.
+		 */
+		EKF_POSITION_STATE_UPDATE
 	}
 
 	public interface OnDroneListener {

--- a/dependencyLibs/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
@@ -241,6 +241,11 @@ public class DroneInterfaces {
          * The gopro status was updated.
          */
         GOPRO_STATUS_UPDATE,
+
+		/**
+		 * The ekf status was updated.
+		 */
+		EKF_STATUS_UPDATE,
 	}
 
 	public interface OnDroneListener {

--- a/dependencyLibs/Core/src/org/droidplanner/core/drone/variables/Home.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/drone/variables/Home.java
@@ -4,17 +4,22 @@ import com.MAVLink.common.msg_mission_item;
 import com.MAVLink.enums.MAV_CMD;
 import com.MAVLink.enums.MAV_FRAME;
 
+import org.droidplanner.core.MAVLink.MavLinkWaypoint;
+import org.droidplanner.core.drone.DroneInterfaces;
 import org.droidplanner.core.drone.DroneInterfaces.DroneEventsType;
 import org.droidplanner.core.drone.DroneVariable;
 import org.droidplanner.core.helpers.coordinates.Coord2D;
 import org.droidplanner.core.model.Drone;
 
-public class Home extends DroneVariable {
+public class Home extends DroneVariable implements DroneInterfaces.OnDroneListener {
+    public static final int HOME_WAYPOINT_INDEX = 0;
+
     private Coord2D coordinate;
     private double altitude = 0;
 
     public Home(Drone drone) {
         super(drone);
+        drone.addDroneListener(this);
     }
 
     public boolean isValid() {
@@ -70,4 +75,17 @@ public class Home extends DroneVariable {
         return mavMsg;
     }
 
+    @Override
+    public void onDroneEvent(DroneEventsType event, Drone drone) {
+        switch(event){
+            case EKF_POSITION_STATE_UPDATE:
+                if(drone.getState().isEkfPositionOk())
+                    requestHomeUpdate(myDrone);
+                break;
+        }
+    }
+
+    private static void requestHomeUpdate(Drone drone){
+        MavLinkWaypoint.requestWayPoint(drone, HOME_WAYPOINT_INDEX);
+    }
 }


### PR DESCRIPTION
* Add support to access the ekf state of the vehicle:
  The [`EkfStatus`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java) object for a vehicle can be retrieved by calling [`State#getEkfStatus`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java#L121-L123).

* Add a set of events to notify of the vehicle ekf state update:
  * Updates to the ekf state are reported via the [`STATE_EKF_REPORT`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java#L144) attribute event. Upon receiving the event, the updated ekf state can be retrieved via [`State#getEkfStatus`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/State.java#L121-L123).
  * Updates to the ekf state position accuracy are reported via the [`STATE_EKF_POSITION`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/attribute/AttributeEvent.java#L149) attribute event. Upon receiving the event, [`EkfStatus#isPositionOk()`](https://github.com/DroidPlanner/DroneKit-Android/blob/be6fd75a49085bf4b3ac33035bf798a1d880a5dc/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/property/EkfStatus.java#L118-L126) can be used to find out if the position accuracy is adequate.