### PR TITLE
Add DO_LAND_START mission item

### DIFF
--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/MissionItemType.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/MissionItemType.java
@@ -16,10 +16,12 @@ import com.o3dr.services.android.lib.drone.mission.item.command.YawCondition;
 import com.o3dr.services.android.lib.drone.mission.item.complex.StructureScanner;
 import com.o3dr.services.android.lib.drone.mission.item.complex.Survey;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.Circle;
+import com.o3dr.services.android.lib.drone.mission.item.spatial.DoLandStart;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.Land;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.RegionOfInterest;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.SplineWaypoint;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.Waypoint;
+import com.o3dr.services.android.lib.drone.property.Type;
 import com.o3dr.services.android.lib.util.ParcelableUtils;
 
 /**
@@ -110,6 +112,23 @@ public enum MissionItemType {
         @Override
         protected Creator<ReturnToLaunch> getMissionItemCreator() {
             return ReturnToLaunch.CREATOR;
+        }
+    },
+
+    DO_LAND_START("Do Land start") {
+        @Override
+        public boolean isTypeSupported(Type vehicleType){
+            return super.isTypeSupported(vehicleType) && vehicleType.getDroneType() == Type.TYPE_PLANE;
+        }
+
+        @Override
+        public MissionItem getNewItem() {
+            return new DoLandStart();
+        }
+
+        @Override
+        protected Creator<DoLandStart> getMissionItemCreator() {
+            return DoLandStart.CREATOR;
         }
     },
 
@@ -259,4 +278,12 @@ public enum MissionItemType {
         return missionItem;
     }
 
+    /**
+     * Indicates if the mission item is supported on the given vehicle type.
+     * @param vehicleType Vehicle type to check against (i.e: plane, copter, rover...)
+     * @return true the mission item is supported, false otherwise.
+     */
+    public boolean isTypeSupported(Type vehicleType){
+        return vehicleType != null;
+    }
 }

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/DoLandStart.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/DoLandStart.java
@@ -1,0 +1,36 @@
+package com.o3dr.services.android.lib.drone.mission.item.spatial;
+
+import android.os.Parcel;
+
+import com.o3dr.services.android.lib.drone.mission.MissionItemType;
+import com.o3dr.services.android.lib.drone.mission.item.MissionItem;
+
+public class DoLandStart extends BaseSpatialItem implements android.os.Parcelable {
+
+    public DoLandStart(){
+        super(MissionItemType.DO_LAND_START);
+    }
+
+    public DoLandStart(DoLandStart copy){
+        super(copy);
+    }
+
+    private DoLandStart(Parcel in) {
+        super(in);
+    }
+
+    @Override
+    public MissionItem clone() {
+        return new DoLandStart(this);
+    }
+
+    public static final Creator<DoLandStart> CREATOR = new Creator<DoLandStart>() {
+        public DoLandStart createFromParcel(Parcel source) {
+            return new DoLandStart(source);
+        }
+
+        public DoLandStart[] newArray(int size) {
+            return new DoLandStart[size];
+        }
+    };
+}

--- a/ServiceApp/src/org/droidplanner/services/android/utils/ProxyUtils.java
+++ b/ServiceApp/src/org/droidplanner/services/android/utils/ProxyUtils.java
@@ -16,6 +16,7 @@ import com.o3dr.services.android.lib.drone.mission.item.complex.StructureScanner
 import com.o3dr.services.android.lib.drone.mission.item.complex.Survey;
 import com.o3dr.services.android.lib.drone.mission.item.complex.SurveyDetail;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.Circle;
+import com.o3dr.services.android.lib.drone.mission.item.spatial.DoLandStart;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.Land;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.RegionOfInterest;
 import com.o3dr.services.android.lib.drone.mission.item.spatial.SplineWaypoint;
@@ -26,6 +27,7 @@ import org.droidplanner.core.mission.Mission;
 import org.droidplanner.core.mission.commands.ConditionYaw;
 import org.droidplanner.core.mission.commands.ReturnToHome;
 import org.droidplanner.core.mission.commands.SetRelayImpl;
+import org.droidplanner.core.mission.waypoints.DoLandStartImpl;
 import org.droidplanner.core.survey.CameraInfo;
 import org.droidplanner.core.survey.SurveyData;
 
@@ -149,6 +151,15 @@ public class ProxyUtils {
 
                 org.droidplanner.core.mission.waypoints.Land temp = new org.droidplanner.core
                         .mission.waypoints.Land(mission, MathUtils.latLongToCoord2D(proxy
+                        .getCoordinate()));
+
+                missionItemImpl = temp;
+                break;
+            }
+            case DO_LAND_START: {
+                DoLandStart proxy = (DoLandStart) proxyItem;
+
+                DoLandStartImpl temp = new DoLandStartImpl(mission, MathUtils.latLongToCoord2D(proxy
                         .getCoordinate()));
 
                 missionItemImpl = temp;
@@ -316,7 +327,15 @@ public class ProxyUtils {
                 proxyMissionItem = temp;
                 break;
             }
+            case DO_LAND_START: {
+                DoLandStartImpl source = (DoLandStartImpl) itemImpl;
 
+                DoLandStart temp = new DoLandStart();
+                temp.setCoordinate(MathUtils.coord3DToLatLongAlt(source.getCoordinate()));
+
+                proxyMissionItem = temp;
+                break;
+            }
             case CIRCLE: {
                 org.droidplanner.core.mission.waypoints.Circle source = (org.droidplanner.core.mission.waypoints.Circle) itemImpl;
 

--- a/dependencyLibs/Core/src/org/droidplanner/core/mission/Mission.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/mission/Mission.java
@@ -17,6 +17,7 @@ import org.droidplanner.core.mission.commands.ReturnToHome;
 import org.droidplanner.core.mission.commands.SetServo;
 import org.droidplanner.core.mission.commands.Takeoff;
 import org.droidplanner.core.mission.waypoints.Circle;
+import org.droidplanner.core.mission.waypoints.DoLandStartImpl;
 import org.droidplanner.core.mission.waypoints.Land;
 import org.droidplanner.core.mission.waypoints.RegionOfInterest;
 import org.droidplanner.core.mission.waypoints.SpatialCoordItem;
@@ -265,6 +266,9 @@ public class Mission extends DroneVariable {
                     break;
                 case MAV_CMD.MAV_CMD_NAV_LAND:
                     received.add(new Land(msg, this));
+                    break;
+                case MAV_CMD.MAV_CMD_DO_LAND_START:
+                    received.add(new DoLandStartImpl(msg, this));
                     break;
                 case MAV_CMD.MAV_CMD_NAV_TAKEOFF:
                     received.add(new Takeoff(msg, this));

--- a/dependencyLibs/Core/src/org/droidplanner/core/mission/MissionItemType.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/mission/MissionItemType.java
@@ -11,6 +11,7 @@ import org.droidplanner.core.mission.commands.SetServo;
 import org.droidplanner.core.mission.commands.Takeoff;
 import org.droidplanner.core.mission.survey.Survey;
 import org.droidplanner.core.mission.waypoints.Circle;
+import org.droidplanner.core.mission.waypoints.DoLandStartImpl;
 import org.droidplanner.core.mission.waypoints.Land;
 import org.droidplanner.core.mission.waypoints.RegionOfInterest;
 import org.droidplanner.core.mission.waypoints.SplineWaypoint;
@@ -25,6 +26,7 @@ public enum MissionItemType {
     TAKEOFF("Takeoff"),
     RTL("Return to Launch"),
     LAND("Land"),
+    DO_LAND_START("Do Land Start"),
     CIRCLE("Circle"),
     ROI("Region of Interest"),
     SURVEY("Survey"),
@@ -64,6 +66,8 @@ public enum MissionItemType {
                 return new ReturnToHome(referenceItem);
             case LAND:
                 return new Land(referenceItem);
+            case DO_LAND_START:
+                return new DoLandStartImpl(referenceItem);
             case CIRCLE:
                 return new Circle(referenceItem);
             case ROI:

--- a/dependencyLibs/Core/src/org/droidplanner/core/mission/waypoints/DoLandStartImpl.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/mission/waypoints/DoLandStartImpl.java
@@ -1,0 +1,53 @@
+package org.droidplanner.core.mission.waypoints;
+
+import com.MAVLink.common.msg_mission_item;
+import com.MAVLink.enums.MAV_CMD;
+
+import org.droidplanner.core.helpers.coordinates.Coord2D;
+import org.droidplanner.core.helpers.coordinates.Coord3D;
+import org.droidplanner.core.mission.Mission;
+import org.droidplanner.core.mission.MissionItem;
+import org.droidplanner.core.mission.MissionItemType;
+
+import java.util.List;
+
+public class DoLandStartImpl extends SpatialCoordItem {
+
+    public DoLandStartImpl(MissionItem item) {
+        super(item);
+        setAltitude((0.0));
+    }
+
+    public DoLandStartImpl(Mission mission) {
+        this(mission, new Coord2D(0, 0));
+    }
+
+    public DoLandStartImpl(Mission mMission, Coord2D coord) {
+        super(mMission, new Coord3D(coord, (0)));
+    }
+
+    public DoLandStartImpl(msg_mission_item msg, Mission mission) {
+        super(mission, null);
+        unpackMAVMessage(msg);
+    }
+
+
+    @Override
+    public List<msg_mission_item> packMissionItem() {
+        List<msg_mission_item> list = super.packMissionItem();
+        msg_mission_item mavMsg = list.get(0);
+        mavMsg.command = MAV_CMD.MAV_CMD_DO_LAND_START;
+        return list;
+    }
+
+    @Override
+    public void unpackMAVMessage(msg_mission_item mavMsg) {
+        super.unpackMAVMessage(mavMsg);
+    }
+
+    @Override
+    public MissionItemType getType() {
+        return MissionItemType.DO_LAND_START;
+    }
+
+}


### PR DESCRIPTION
DO_LAND_START mission item acts as a marker for the start of a landing
sequence. It is required for RTL auto landing (RTL_AUTOLAND != 0).

See http://plane.ardupilot.com/wiki/flying/automatic-landing/#using_do_land_start