### PR TITLE
fix battery voltage overflow

### DIFF
--- a/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
+++ b/dependencyLibs/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
@@ -98,7 +98,14 @@ public class MavLinkMsgHandler {
 
             case msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS:
                 msg_sys_status m_sys = (msg_sys_status) msg;
-                drone.getBattery().setBatteryState(m_sys.voltage_battery / 1000.0,
+
+                //Correct for any short overflow that may have occurred
+                double milliVoltage = m_sys.voltage_battery;
+                if(milliVoltage < 0){
+                    milliVoltage = Short.MAX_VALUE + (milliVoltage - Short.MIN_VALUE);
+                }
+
+                drone.getBattery().setBatteryState(milliVoltage / 1000.0,
                         m_sys.battery_remaining, m_sys.current_battery / 100.0);
                 checkControlSensorsHealth(m_sys);
                 break;


### PR DESCRIPTION
Fixes DroidPlanner/Tower#1466

The flight code sends the voltage as millivolts in an `unsigned short`.  This data type doesn't exist in java, so it is converted to a short as soon as it arrives.  This is where the overflow occurs.  This patch will just see if the number is negative and then recalculate what it should have been and store it in a double.

I didn't want to change the underlying MAVLink implementation to use `int`s, because those implementations were autogenerated, and this issue would occur as soon as they were regenerated.