### PR TITLE
Add pitch parameter to Takeoff cmd

### DIFF
--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/command/Takeoff.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/command/Takeoff.java
@@ -16,6 +16,7 @@ public class Takeoff extends MissionItem implements MissionItem.Command, android
     public static final double DEFAULT_TAKEOFF_ALTITUDE = 10.0;
 
     private double takeoffAltitude;
+    private double minPitch;
 
     public Takeoff(){
         super(MissionItemType.TAKEOFF);
@@ -24,6 +25,7 @@ public class Takeoff extends MissionItem implements MissionItem.Command, android
     public Takeoff(Takeoff copy){
         this();
         takeoffAltitude = copy.takeoffAltitude;
+        setMinPitch(copy.getMinPitch());
     }
 
     public double getTakeoffAltitude() {
@@ -38,11 +40,13 @@ public class Takeoff extends MissionItem implements MissionItem.Command, android
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
         dest.writeDouble(this.takeoffAltitude);
+        dest.writeDouble(this.getMinPitch());
     }
 
     private Takeoff(Parcel in) {
         super(in);
         this.takeoffAltitude = in.readDouble();
+        this.setMinPitch(in.readDouble());
     }
 
     @Override
@@ -59,4 +63,12 @@ public class Takeoff extends MissionItem implements MissionItem.Command, android
             return new Takeoff[size];
         }
     };
+
+    public double getMinPitch() {
+        return minPitch;
+    }
+
+    public void setMinPitch(double minPitch) {
+        this.minPitch = minPitch;
+    }
 }

--- a/ServiceApp/src/org/droidplanner/services/android/core/mission/Mission.java
+++ b/ServiceApp/src/org/droidplanner/services/android/core/mission/Mission.java
@@ -2,18 +2,13 @@ package org.droidplanner.services.android.core.mission;
 
 import android.util.Pair;
 
-import android.util.SparseArray;
-import android.util.SparseIntArray;
-
 import com.MAVLink.common.msg_mission_ack;
 import com.MAVLink.common.msg_mission_item;
 import com.MAVLink.enums.MAV_CMD;
-import com.google.android.gms.maps.model.LatLng;
-import com.o3dr.services.android.lib.coordinate.LatLong;
-import com.o3dr.services.android.lib.util.MathUtils;
 
 import org.droidplanner.services.android.core.drone.DroneInterfaces.DroneEventsType;
 import org.droidplanner.services.android.core.drone.DroneVariable;
+import org.droidplanner.services.android.core.drone.autopilot.MavLinkDrone;
 import org.droidplanner.services.android.core.helpers.coordinates.Coord2D;
 import org.droidplanner.services.android.core.helpers.coordinates.Coord3D;
 import org.droidplanner.services.android.core.helpers.geoTools.GeoTools;
@@ -32,13 +27,10 @@ import org.droidplanner.services.android.core.mission.waypoints.RegionOfInterest
 import org.droidplanner.services.android.core.mission.waypoints.SpatialCoordItem;
 import org.droidplanner.services.android.core.mission.waypoints.SplineWaypoint;
 import org.droidplanner.services.android.core.mission.waypoints.Waypoint;
-import org.droidplanner.services.android.core.drone.autopilot.MavLinkDrone;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import timber.log.Timber;
 
 /**
  * This implements a mavlink mission. A mavlink mission is a set of

--- a/ServiceApp/src/org/droidplanner/services/android/core/mission/commands/Takeoff.java
+++ b/ServiceApp/src/org/droidplanner/services/android/core/mission/commands/Takeoff.java
@@ -15,6 +15,7 @@ public class Takeoff extends MissionCMD {
     public static final double DEFAULT_TAKEOFF_ALTITUDE = 10.0;
 
     private double finishedAlt = 10;
+    private double minPitch = 0;
 
     public Takeoff(MissionItem item) {
         super(item);
@@ -28,6 +29,13 @@ public class Takeoff extends MissionCMD {
     public Takeoff(Mission mission, double altitude) {
         super(mission);
         finishedAlt = altitude;
+        setMinPitch(0);
+    }
+
+    public Takeoff(Mission mission, double altitude, double minPitch) {
+        super(mission);
+        finishedAlt = altitude;
+        setMinPitch(minPitch);
     }
 
     @Override
@@ -37,12 +45,15 @@ public class Takeoff extends MissionCMD {
         mavMsg.command = MAV_CMD.MAV_CMD_NAV_TAKEOFF;
         mavMsg.frame = MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT;
         mavMsg.z = (float) finishedAlt;
+        if (minPitch > 0)
+            mavMsg.param1 = (float)getMinPitch();
         return list;
     }
 
     @Override
     public void unpackMAVMessage(msg_mission_item mavMsg) {
         finishedAlt = (mavMsg.z);
+        minPitch = mavMsg.param1;
     }
 
     @Override
@@ -56,5 +67,13 @@ public class Takeoff extends MissionCMD {
 
     public void setFinishedAlt(double finishedAlt) {
         this.finishedAlt = finishedAlt;
+    }
+
+    public double getMinPitch() {
+        return minPitch;
+    }
+
+    public void setMinPitch(double minPitch) {
+        this.minPitch = minPitch;
     }
 }

--- a/ServiceApp/src/org/droidplanner/services/android/utils/ProxyUtils.java
+++ b/ServiceApp/src/org/droidplanner/services/android/utils/ProxyUtils.java
@@ -129,7 +129,7 @@ public class ProxyUtils {
                 Takeoff proxy = (Takeoff) proxyItem;
 
                 org.droidplanner.services.android.core.mission.commands.Takeoff temp = new org.droidplanner.services.android.core
-                        .mission.commands.Takeoff(mission, (proxy.getTakeoffAltitude()));
+                        .mission.commands.Takeoff(mission, proxy.getTakeoffAltitude(), proxy.getMinPitch());
 
                 missionItemImpl = temp;
                 break;
@@ -326,6 +326,7 @@ public class ProxyUtils {
 
                 Takeoff temp = new Takeoff();
                 temp.setTakeoffAltitude(source.getFinishedAlt());
+                temp.setMinPitch(source.getMinPitch());
 
                 proxyMissionItem = temp;
                 break;


### PR DESCRIPTION
Specify the pitch (climb angle) to hold during takeoff command execution.
The value specifies the minimum pitch for the case with airspeed sensor
and the target pitch for the case without. If you want to use the pitch
parameter, please use `public Takeoff(Mission mission, double altitude,
double minPitch)` constructor at 3DR Services client (Tower).

See http://planner.ardupilot.com/wiki/common-mavlink-mission-command-messages-mav_cmd/#mav_cmd_nav_takeoff

Signed-off-by: Valery V. Vorotyntsev <valery.vv@gmail.com>